### PR TITLE
[PKG-2566] json_stream 2.3.2 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python
     - setuptools
     - wheel
+    - pip
   run:
     - python
     - json-stream-rs-tokenizer >=0.4.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,31 +11,38 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 
 requirements:
   host:
-    - python >=3.5,<4.0
+    - python
     - setuptools
     - wheel
-    - pip
   run:
-    - python >=3.5,<4.0
+    - python
     - json-stream-rs-tokenizer >=0.4.17
 
 test:
   imports:
     - json_stream
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
+  dev_url: https://github.com/daggaz/json-stream
+  doc_url: https://github.com/daggaz/json-stream/tree/2.3.2#usage
+  description: |
+    Simple streaming JSON parser and encoder.
+    When reading JSON data, json-stream can decode JSON data in a streaming manner, providing a pythonic dict/list-like interface, or a visitor-based interfeace. Can stream from files, URLs or iterators.
+    When writing JSON data, json-stream can stream JSON objects as you generate them.
+    These techniques allow you to reduce memory consumption and latency.
   summary: Streaming JSON encoder and decoder
   home: https://github.com/daggaz/json-stream
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,19 @@ test:
     - json_stream
   requires:
     - pip
+    - pytest
+  source_files:
+    - src/json_stream/tests
   commands:
     - pip check
+    - cd src/json_stream/tests
+    # remove tests that fail because the package author
+    # mocks json_stream_rs_tokenizer.py by overwriting it
+    # before executing tests with:
+    # - cp stub_json_stream_rs_tokenizer.py src/json_stream_rs_tokenizer.py
+    - del test_tokenizer_integration.py test_buffering.py  # [win]
+    - rm test_tokenizer_integration.py test_buffering.py   # [unix]
+    - pytest
 
 about:
   dev_url: https://github.com/daggaz/json-stream

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: b8b450ea8e8e3c239e9e7e38d12fed934e77a353c14b297f8ee345a5ceb25b91
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 


### PR DESCRIPTION
[PKG-2566] json_stream 2.3.2 ❄️

dev url: https://github.com/daggaz/json-stream/tree/2.3.2
conda-forge: https://github.com/conda-forge/json_stream-feedstock
dependencies: https://github.com/daggaz/json-stream/blob/2.3.2/pyproject.toml

changes:
- new repository
- fix linter
- [add abs.yaml for sfe1ed40 channel](https://github.com/AnacondaRecipes/json_stream-feedstock/pull/1/commits/67deec4f92fc86d11778c3a2c83cec369e7f8af1)
- depends on `json-stream-rs-tokenizer >= 0.4.17` AnacondaRecipes/json-stream-rs-tokenizer-feedstock#1
- [add some upstream tests](https://github.com/AnacondaRecipes/json_stream-feedstock/pull/1/commits/4f332622e082c278a9f60f67a56ce8d9c7b1cd41)


[PKG-2566]: https://anaconda.atlassian.net/browse/PKG-2566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ